### PR TITLE
fix copy js

### DIFF
--- a/source/js/copy.js
+++ b/source/js/copy.js
@@ -7,12 +7,6 @@ $(function () {
   // copy function
   function copy (text, ctx) {
     if (document.queryCommandSupported && document.queryCommandSupported('copy')) {
-      var textarea = document.createElement('textarea')
-      textarea.style.position = 'fixed' // Prevent scrolling to bottom of page in MS Edge.
-      document.body.appendChild(textarea)
-      textarea.textContent = text
-      textarea.focus()
-      textarea.setSelectionRange(0, textarea.value.length)
       try {
         document.execCommand('copy') // Security exception may be thrown by some browsers.
         $(ctx).prev('.copy-notice')
@@ -37,9 +31,7 @@ $(function () {
             easing: 'easeOutQuint'
           })
         return false
-      } finally {
-        document.body.removeChild(textarea)
-      }
+      } 
     } else {
       $(ctx).prev('.copy-notice').text(GLOBAL.copy.noSupport)
     }
@@ -53,6 +45,6 @@ $(function () {
     selection.addRange(range)
     var text = selection.toString()
     copy(text, this)
-    text = ''
+    selection.removeAllRanges()
   })
 })


### PR DESCRIPTION
Remove unnecessary code in copy.js.   
This will also fix a bug where MS-Edge won't copy line breaks correctly.