### PR TITLE
fix issue that cannot show counts of disqus comments

### DIFF
--- a/layout/includes/comments/disqus.pug
+++ b/layout/includes/comments/disqus.pug
@@ -1,13 +1,14 @@
 if theme.disqus.enable
   #disqus_thread
   script.
+    var disqus_shortname = '!{theme.disqus.shortname}'
     var disqus_config = function () {
       this.page.url = '!{ page.permalink }';
       this.page.identifier = '!{ page.path }';
       this.page.title = '!{ page.title }';
     }
     var d = document, s = d.createElement('script');
-    s.src = "https://!{theme.disqus.shortname}.disqus.com/embed.js";
+    s.src = "https://" + disqus_shortname +".disqus.com/embed.js";
     s.setAttribute('data-timestamp', '' + +new Date());
     (d.head || d.body).appendChild(s);
   if theme.disqus.count


### PR DESCRIPTION
问题：
使用 disqus 时，发现评论数没办法显示

解决：
添加一个全局变量 disqus_shortname, 因为 disqus 会用这个全局变量再拼一个请求 count_data 的 URI。