### PR TITLE
在 footer 区添加了一个 HostedByCodingPages

### DIFF
--- a/layout/includes/footer.pug
+++ b/layout/includes/footer.pug
@@ -13,6 +13,8 @@
     span= _p('footer.theme') + ' - '
     a(href='https://github.com/Molunerfinn/hexo-theme-melody')
       span Melody
+  if theme.HostedByCodingPages
+    span Hosted by <a target="_blank" rel="external nofollow" href="https://pages.coding.me"><b>Coding Pages</b></a>     
   if theme.ICP.enable
     .icp
       a(href=theme.ICP.url)

--- a/layout/includes/footer.pug
+++ b/layout/includes/footer.pug
@@ -13,8 +13,8 @@
     span= _p('footer.theme') + ' - '
     a(href='https://github.com/Molunerfinn/hexo-theme-melody')
       span Melody
-  if theme.custom_text
-    .custom_text!=`${theme.custom_text}`   
+  if theme.footer_custom_text
+    .footer_custom_text!=`${theme.footer_custom_text}`   
   if theme.ICP.enable
     .icp
       a(href=theme.ICP.url)

--- a/layout/includes/footer.pug
+++ b/layout/includes/footer.pug
@@ -13,8 +13,8 @@
     span= _p('footer.theme') + ' - '
     a(href='https://github.com/Molunerfinn/hexo-theme-melody')
       span Melody
-  if theme.HostedByCodingPages
-    span Hosted by <a target="_blank" rel="external nofollow" href="https://pages.coding.me"><b>Coding Pages</b></a>     
+  if theme.custom_text
+    .custom_text!=`${theme.custom_text}`   
   if theme.ICP.enable
     .icp
       a(href=theme.ICP.url)


### PR DESCRIPTION
# 新的 commit
在主题配置文件中添加 `custom_text` 字段，就可以在 `footer` 区任意添加任意文字（支持 HTML 语法）。


# 旧的 commit
这个用于 coding pages 创建的博客页面。
在主题配置文件中加入：
`HostedByCodingPages: true`

本来想从配置文件读取一段HTML格式的文本的，但不会操作，只能强制在 `footer.pug` 里添加了。
我本来想实现的操作是这样的：
 `footer.pug` 中
```
{% if theme.footer.custom_text %}
  <div class="footer-custom">{#
  #}{{ theme.footer.custom_text }}{#
#}</div>
{% endif %}
```
主题配置文件中：
`custom_text: Hosted by <a target="_blank" rel="external nofollow" href="https://pages.coding.me"><b>Coding Pages</b></a>`