### PR TITLE
Changed: word wrap(自动换行)  for code

### DIFF
--- a/source/css/_highlight/highlight.styl
+++ b/source/css/_highlight/highlight.styl
@@ -25,6 +25,9 @@ $code-block
   color: $highlight-foreground
   font-size: $code-font-size
   line-height: $line-height-code-block
+  // word wrap for code
+  white-space: pre-wrap;
+  counter-reset: line;
 
 figure.highlight
   position: relative
@@ -79,6 +82,15 @@ blockquote
       &::selection
         background: $highlight-selection
         color: $highlight-foreground
+      
+      &:before
+        counter-increment: line;
+        content: counter(line);
+        display: inline-block;
+        padding: 0 .5em;
+        width: 1em;
+        margin-right: .5em;
+        color: #888
 
     table
       position: relative


### PR DESCRIPTION
I find long code cross one line is really difficult to read, so I add the word wrap(自动换行) feature, which also has to disable default line numbers.

# Before
<img src="https://user-images.githubusercontent.com/24741764/41469677-bcdccbfa-70e0-11e8-8195-8d72f417d4f7.png" height=150>

# After

<img src="https://user-images.githubusercontent.com/24741764/41469682-c23741d4-70e0-11e8-8879-617794298260.png" height=150>

# More examples
<img src="https://user-images.githubusercontent.com/24741764/41469689-ca9797e8-70e0-11e8-8366-589ac6085c12.png" height=300>

# How to configure hexo for word wrap

1. Modify the `_config.yml` in your blog's root folder to disable the `line_number`
  ```yml
  highlight:
    enable: false
    line_number: false
    auto_detect: false
    tab_replace:
  ```
2. For me, I need to update `hexo-server` to make preview displays properly
  ```
  npm install hexo-server --save
  ```

# Feature request

I have another idea, but I don't know how to achieve it. Apply **word wrap** according to the config in the blog's root `_config` file:

1. Case `line_number: true`
  
    Use the normal scroll to view more of a long line.

2. Case `line_number: false`

    Use word wrap.