### PR TITLE
Fixed: indented code language bar position

### DIFF
--- a/source/css/_highlight/highlight.styl
+++ b/source/css/_highlight/highlight.styl
@@ -88,8 +88,6 @@ blockquote
 
       &:before
         position: fixed
-        right: 0
-        left: 0
         z-index: 1
         display: inline-block
         margin-top: -1.4rem


### PR DESCRIPTION
Hey, I found a little problem about position of "Code" in language bar and fixed it.

# Before

<img src="https://user-images.githubusercontent.com/24741764/41479571-2eed0fe4-70fe-11e8-9622-eaad43c2affe.png" height="300">


# After

<img src="https://user-images.githubusercontent.com/24741764/41479561-25865a28-70fe-11e8-995f-d2cc598ac3dc.png" height="300">