### PR TITLE
Update fontawesome & fancybox

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -106,7 +106,7 @@ scripts:
 # ---------------
 cdn:
   css:
-    fontawesome: https://cdn.jsdelivr.net/npm/font-awesome@4.7.0/css/font-awesome.min.css
+    fontawesome: https://cdn.jsdelivr.net/npm/font-awesome@latest/css/font-awesome.min.css
   js:
     anime: /js/third-party/anime.min.js
     jquery: /js/third-party/jquery.min.js

--- a/_config.yml
+++ b/_config.yml
@@ -108,11 +108,11 @@ cdn:
   css:
     fontawesome: https://cdn.jsdelivr.net/npm/font-awesome@latest/css/font-awesome.min.css
   js:
-    anime: /js/third-party/anime.min.js
-    jquery: /js/third-party/jquery.min.js
-    fancybox: /js/third-party/jquery.fancybox.min.js
-    velocity: /js/third-party/velocity.min.js 
-    velocity-ui: /js/third-party/velocity.ui.min.js 
+    anime: https://cdn.jsdelivr.net/npm/animejs@latest/anime.min.js
+    jquery: https://cdn.jsdelivr.net/npm/jquery@latest/dist/jquery.min.js
+    fancybox: https://cdn.jsdelivr.net/npm/@fancyapps/fancybox@latest/dist/jquery.fancybox.min.js
+    velocity: https://cdn.jsdelivr.net/npm/velocity-animate@latest/velocity.min.js
+    velocity-ui: https://cdn.jsdelivr.net/npm/velocity-ui-pack@latest/velocity.ui.min.js
 
 # Post info settings
 # ---------------

--- a/source/css/index.styl
+++ b/source/css/index.styl
@@ -1,6 +1,9 @@
 @import "nib"
 // third-party
-@import "_third-party/jquery.fancybox.min.css"
+if hexo-config("cdn.js.fancybox") == "https://cdn.jsdelivr.net/npm/@fancyapps/fancybox@latest/dist/jquery.fancybox.min.js"
+  @import url("https://cdn.jsdelivr.net/npm/@fancyapps/fancybox@latest/dist/jquery.fancybox.min.css")
+else 
+  @import "_third-party/jquery.fancybox.min.css"
 @import "_third-party/normalize.min.css"
 // project
 @import "var"

--- a/source/js/fancybox.js
+++ b/source/js/fancybox.js
@@ -6,10 +6,10 @@ $(function () {
   for (var i = 0; i < imgList.length; i++) {
     var $a = $(
       '<a href="' +
-        imgList[i].src +
-        '" data-fancybox="group" data-caption="' +
-        imgList[i].alt +
-        '" class="fancybox"></a>'
+      imgList[i].src +
+      '" data-fancybox="group" data-caption="' +
+      imgList[i].alt +
+      '" class="fancybox"></a>'
     )
     var alt = imgList[i].alt
     var $wrap = $(imgList[i]).wrap($a)
@@ -21,7 +21,15 @@ $(function () {
   $().fancybox({
     selector: '[data-fancybox]',
     loop: true,
-    transitionEffect: 'slide'
+    transitionEffect: 'slide',
+    buttons: [
+      "share",
+      "slideShow",
+      "fullScreen",
+      "download",
+      "thumbs",
+      "close"
+    ],
   })
 
   var galleryItem = $('.gallery-item')


### PR DESCRIPTION
Hi, I updated the font-awesome and fancybox to latest.(respect to #131 )

The font-awesome keeps working as usual. However, the new fancybox js library won't work together with the old `_third-party/jquery.fancybox.min.css`. So I update the css file, too. Now we use the latest css file only if the js is latest.

**Before(If you don't modify your `melody.yml`, nothing will break):**

![don t change](https://user-images.githubusercontent.com/24741764/44615336-9be0c980-a86a-11e8-808d-4c046da2274c.PNG)

**After:**

![after](https://user-images.githubusercontent.com/24741764/44615340-af8c3000-a86a-11e8-96a5-13f36750d588.PNG)

You can see the changes on [my blog](https://upupming.site/#group-1). Hope it helps!

By the way, I don't think it's good idea to let user set js cdn, because our code may only work with specific version of the jquery, etc. And it makes changes more difficult. How about abandon this config?