### PR TITLE
Added: KaTeX support & yml, gradle code language

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -73,6 +73,12 @@ mathjax:
   enable: false
   cdn: https://cdn.jsdelivr.net/npm/mathjax/MathJax.js?config=TeX-AMS-MML_HTMLorMML
 
+# KaTeX
+# ---------------
+katex:
+  enable: false
+  cdn:
+    css: https://cdn.jsdelivr.net/npm/katex@latest/dist/katex.min.css
 
 # Toggle fireworks (IE >= 10)
 # ---------------

--- a/layout/includes/additional-js.pug
+++ b/layout/includes/additional-js.pug
@@ -3,6 +3,9 @@ if (theme.algolia_search.enable)
 if (theme.mathjax && theme.mathjax.enable)
   if(!is_tag() && !is_category() && !is_archive())
     include ./third-party/mathjax.pug
+if (theme.katex && theme.katex.enable)
+  if(!is_tag() && !is_category() && !is_archive())
+    include ./third-party/katex.pug
 if (theme.local_search && theme.local_search.enable)
   script(src=url_for('/js/search/local-search.js'))
   

--- a/layout/includes/third-party/katex.pug
+++ b/layout/includes/third-party/katex.pug
@@ -1,0 +1,1 @@
+link(rel="stylesheet" type="text/css" href=theme.katex.cdn.css)

--- a/source/css/_highlight/highlight.styl
+++ b/source/css/_highlight/highlight.styl
@@ -2,7 +2,7 @@
 @require "theme"
 @require "diff"
 
-languages = "js" "javascript" "python" "ruby" "xml" "html" "css" "perl" "sql" "coffeescript" "java" "scala" "kotlin" "c" "c\+\+" "go" "less" "sass" "scss" "stylus" "styl" "typescript" "ts" "bash"
+languages = "js" "javascript" "python" "ruby" "xml" "html" "css" "perl" "sql" "coffeescript" "java" "scala" "kotlin" "c" "c\+\+" "go" "less" "sass" "scss" "stylus" "styl" "typescript" "ts" "bash" "yml" "gradle"
 wordWrap = !hexo-config("rootConfig.highlight.line_number") && hexo-config("code_word_wrap")
 
 loopForLanguages()


### PR DESCRIPTION
# KaTeX support

![image](https://user-images.githubusercontent.com/24741764/47160200-015cae00-d322-11e8-98db-50459d0ade46.png)

[This post](https://upupming.site/2018/10/18/katex-test) is a demo for KaTeX support with `melody`, and it's rendered exactly same as on [katex.org](https://katex.org/docs/supported.html).

# Code language

Added `yml` and `gradle`.