### PR TITLE
Fix table of contents not expanding nested subsections

### DIFF
--- a/source/js/scroll.js
+++ b/source/js/scroll.js
@@ -80,6 +80,9 @@ $(function () {
 
   // expand toc-item
   function expandToc ($item) {
+    if ($item.is(':visible')) {
+      return
+    }
     $item.velocity('stop').velocity('transition.fadeIn', {
       duration: 500,
       easing: 'easeInQuart'
@@ -110,6 +113,9 @@ $(function () {
   }
 
   // find head position & add active class
+  // DOM Hierarchy:
+  // ol.toc > (li.toc-item, ...)
+  // li.toc-item > (a.toc-link, ol.toc-child > (li.toc-item, ...))
   function findHeadPosition (top) {
     // assume that we are not in the post page if no TOC link be found,
     // thus no need to update the status
@@ -117,10 +123,6 @@ $(function () {
       return false
     }
 
-    if (top < 200) {
-      $('.toc-link').removeClass('active')
-      $('.toc-child').hide()
-    }
     var list = $('#post-content').find('h1,h2,h3,h4,h5,h6')
     var currentId = ''
     list.each(function () {
@@ -129,6 +131,12 @@ $(function () {
         currentId = '#' + $(this).attr('id')
       }
     })
+
+    if (currentId === '') {
+      $('.toc-link').removeClass('active')
+      $('.toc-child').hide()
+    }
+
     var currentActive = $('.toc-link.active')
     if (currentId && currentActive.attr('href') !== currentId) {
       updateAnchor(currentId)
@@ -136,20 +144,19 @@ $(function () {
       $('.toc-link').removeClass('active')
       var _this = $('.toc-link[href="' + currentId + '"]')
       _this.addClass('active')
+
       var parents = _this.parents('.toc-child')
-      if (parents.length > 0) {
-        var child
-        parents.length > 1 ? child = parents.eq(parents.length - 1).find('.toc-child') : child = parents
-        if (child.length > 0 && child.is(':hidden')) {
-          expandToc(child)
-        }
-        parents.eq(parents.length - 1).closest('.toc-item').siblings('.toc-item').find('.toc-child').hide()
-      } else {
-        if (_this.closest('.toc-item').find('.toc-child').is(':hidden')) {
-          expandToc(_this.closest('.toc-item').find('.toc-child'))
-        }
-        _this.closest('.toc-item').siblings('.toc-item').find('.toc-child').hide()
-      }
+      // Returned list is in reverse order of the DOM elements
+      // Thus `parents.last()` is the outermost .toc-child container
+      // i.e. list of subsections
+      var topLink = (parents.length > 0) ? parents.last() : _this
+      expandToc(topLink.closest('.toc-item').find('.toc-child'))
+      topLink
+        // Find all top-level .toc-item containers, i.e. sections
+        // excluding the currently active one
+        .closest('.toc-item').siblings('.toc-item')
+        // Hide their respective list of subsections
+        .find('.toc-child').hide()
     }
   }
 })


### PR DESCRIPTION
文章有多级结构时，边栏目录可能不会展开。

对于如下文章，向下滚动至 Section 2 后回到 Subsubsection 1.1.3 可复现。

<details><summary>post.md</summary>

```md

## Section 1

### Subsection 1.1

Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.

### Subsection 1.2

Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.

### Subsection 1.3

#### Subsubsection 1.3.1

Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.

#### Subsubsection 1.3.2

Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.

## Section 2

Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
```
</details><br>

---

patch 修复了这个问题，目前的实现是以第一级目录为单位折叠（也即展示当前所处大标题下的所有子结构）。

希望可以有用叭