### PR TITLE
Fix nested ordered & unordered lists displayed incorrectly

### DIFF
--- a/source/css/_layout/post.styl
+++ b/source/css/_layout/post.styl
@@ -195,7 +195,7 @@ headStyle(fontsize)
         transition: all 0.3s ease-out
 
   ol
-    li
+    > li
       &:before
         margin-top: 0.2rem
         width: w = 1.2rem
@@ -208,7 +208,7 @@ headStyle(fontsize)
         line-height: h
 
   ul
-    li
+    > li
       &:hover
         &:before
           border-color: $ruby


### PR DESCRIPTION
一个小 bug～ `<ul>` 和 `<ol>` 互相嵌套的情况下会误将后者展示为前者。

<details><summary>post.md</summary>

```md

* Unordered
* Unordered
    1. Ordered
    2. Ordered
* Unordered

1. Ordered
2. Ordered
    * Unordered
    * Unordered
3. Ordered
```
</details><br>