### PR TITLE
Make styles consistent in abstract and post page 

### DIFF
--- a/source/css/_layout/page.styl
+++ b/source/css/_layout/page.styl
@@ -24,69 +24,6 @@ galleryItemStyle(w, h)
       width: $content-width
       height: $iframe-height
 
-    ol,
-    ul
-      margin-top: 0.4rem
-      padding: 0 0 0 0.8rem
-      list-style: none
-      counter-reset: li
-
-      p
-        margin: 0
-
-      ol,
-      ul
-        padding-left: 0.5rem
-
-      li
-        position: relative
-        margin: 0.2rem 0
-        padding: 0.1rem 0.5rem 0.1rem 1.5rem
-
-        &:hover
-          &:before
-            transform: rotate(360deg)
-
-        &:before
-          position: absolute
-          top: 0
-          left: 0
-          background: $light-blue
-          color: $white
-          cursor: pointer
-          transition: all 0.3s ease-out
-
-    ol
-      li
-        &:before
-          margin-top: 0.2rem
-          width: w = 1.2rem
-          height: h = w
-          border-radius: 0.5 * w
-          content: counter(li)
-          counter-increment: li
-          text-align: center
-          font-size: 0.6rem
-          line-height: h
-
-    ul
-      li
-        &:hover
-          &:before
-            border-color: $ruby
-
-        &:before
-          $w = 0.3rem
-          top: 10px
-          margin-left: 0.45rem
-          width: w = $w
-          height: h = w
-          border: 0.5 * w solid $light-blue
-          border-radius: w
-          background: $white
-          content: ""
-          line-height: h
-
   .article-type
     margin-left: 0.3rem
     color: $grey

--- a/source/css/_layout/post.styl
+++ b/source/css/_layout/post.styl
@@ -159,9 +159,6 @@ headStyle(fontsize)
   h6
     headStyle(0.6)
 
-#post-content
-  margin-bottom: 1rem
-
   ol,
   ul
     margin-top: 0.4rem
@@ -224,6 +221,9 @@ headStyle(fontsize)
         background: $white
         content: ""
         line-height: h
+
+#post-content
+  margin-bottom: 1rem
 
 a
   color: $a-link-color

--- a/source/css/_layout/post.styl
+++ b/source/css/_layout/post.styl
@@ -195,7 +195,7 @@ headStyle(fontsize)
         transition: all 0.3s ease-out
 
   ol
-    li
+    > li
       &:before
         margin-top: 0.2rem
         width: w = 1.2rem
@@ -208,7 +208,7 @@ headStyle(fontsize)
         line-height: h
 
   ul
-    li
+    > li
       &:hover
         &:before
           border-color: $ruby


### PR DESCRIPTION
`page.styl` 和 `post.styl` 有一些重复，这也导致了 #167 的改动在主页上没有体现。

所以把这部分 `#post-content` 的样式移到了 `#content-inner` 里面。

之前没有发现所以开启了 PR 轰炸…… 打扰啦 quq

（因为是在原来的分支上重新改，所以有三个 commit，大概需要 squash and merge…