### PR TITLE
Fixed: the overflow problem that LaTex always have

### DIFF
--- a/source/css/_layout/post.styl
+++ b/source/css/_layout/post.styl
@@ -222,6 +222,11 @@ headStyle(fontsize)
         content: ""
         line-height: h
 
+  .katex-html
+    overflow: auto
+    &::-webkit-scrollbar 
+      display: none
+
 #post-content
   margin-bottom: 1rem
 


### PR DESCRIPTION
修复了 LaTex 一直有的小毛病
![Issue](https://i.loli.net/2019/03/30/5c9e568fdd20d.jpg)
![Issue in Practice](https://i.loli.net/2019/03/30/5c9e56902c027.jpg)

给 KaTex 溢出情况下加了 scrollbar 并且将其隐藏以保持美观，拯救了手机用户：
![Result](https://i.loli.net/2019/03/30/5c9e59d07f979.gif)