### PR TITLE
Fixed: missing icon when fontawesomev5 is applied

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -250,7 +250,7 @@ busuanzi:
   site_pv_footer:
   # custom pv span for one page only
   page_pv: true
-  page_pv_header: <i class="fa fa-file-o"></i>
+  page_pv_header: <i class="fa fa-file"></i>
   page_pv_footer:
 
 # Sidebar Settings


### PR DESCRIPTION
When fav5 is applied, the file icon that is used in every post cannot be displayed properly. ![Before Fix](https://i.loli.net/2019/04/05/5ca6f846ea706.png)
It is fixed by changing the name of the icon, which is compatible with both fa v4.7 and v5.
![After Fix](https://i.loli.net/2019/04/05/5ca6f8862fbba.png)