### PR TITLE
A minor mod on social buttons

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -250,7 +250,7 @@ busuanzi:
   site_pv_footer:
   # custom pv span for one page only
   page_pv: true
-  page_pv_header: <i class="fa fa-file-o"></i>
+  page_pv_header: <i class="fa fa-file"></i>
   page_pv_footer:
 
 # Sidebar Settings

--- a/layout/includes/nav.pug
+++ b/layout/includes/nav.pug
@@ -9,7 +9,7 @@ nav#nav(style=bg_img class=flag)
     if(theme.social)
       #site-social-icons
         each url, icon in theme.social
-          a.social-icon(href=url)
+          a.social-icon(href=url target="_blank")
             i(class="fa-" + icon)
         if (theme.algolia_search.enable || theme.local_search && theme.local_search.enable)
           a.social-icon.search


### PR DESCRIPTION
Sometimes it is annoying when it does not open a new tab itself when clicking one of those social media buttons. Since they point to sites that do not belong to our own sites, I made a minor change on that, so when we click on any of those buttons, a new tab pops up.