### PR TITLE
Fixed: bug that can get access to the window object

### DIFF
--- a/layout/includes/nav.pug
+++ b/layout/includes/nav.pug
@@ -9,5 +9,5 @@ nav#nav(style=bg_img class=flag)
     if(theme.social)
       #site-social-icons
         each url, icon in theme.social
-          a.social-icon(href=url target="_blank")
+          a.social-icon(href=url target="_blank" rel="noreferrer noopener")
             i(class="fa-" + icon)


### PR DESCRIPTION
With "_blank", <a> tag can pop up a new tab for users. It useful though, it causes a security problem - the "window" object on the first tab can be retrieved by the newly opened tab which can be used to control elements and do something evil.
Adding the attribute"rel=noopender noreferer" can fix it.