### PR TITLE
:bug: Fix: busuanzi count

### DIFF
--- a/layout/includes/count/busuanzi.pug
+++ b/layout/includes/count/busuanzi.pug
@@ -7,7 +7,8 @@
         span!=theme.busuanzi.site_uv_footer
     if(theme.busuanzi.site_pv)
       if(theme.busuanzi.site_pv)
-        span.footer-separator |
+        if(theme.busuanzi.site_uv)
+          span.footer-separator |
       span#busuanzi_container_site_pv!= theme.busuanzi.site_pv_header
         span#busuanzi_value_site_pv
         span!=theme.busuanzi.site_pv_footer


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13111739/137280557-6226971e-d2fe-4ab4-92e2-8b472d66e935.png)
当启用 site_pv 而不启用 site_uv ,显示上有一些瑕疵。所以做了一些简单优化。
```
busuanzi:
  enable: true
  site_uv: false
  site_uv_header: <i class="fa fa-user"></i>
  site_uv_footer:
  site_pv: true
  site_pv_header: <i class="fa fa-eye"></i>
  site_pv_footer:
  page_pv: true
  page_pv_header: <i class="fa fa-eye"></i>
  page_pv_footer:
```

优化后效果如下：
![image](https://user-images.githubusercontent.com/13111739/137282255-46ae9e2e-7077-4b5f-88a3-a6a1d0a92789.png)
