### PR TITLE
:bug: Fix: support toc auto heightlight for hexo v6

### DIFF
--- a/source/js/scroll.js
+++ b/source/js/scroll.js
@@ -150,7 +150,7 @@ $(function () {
     // encodeURI the toc-item href
     var hexoVersion = GLOBAL_CONFIG.hexoVersion[0]
 
-    if (hexoVersion === '5') {
+    if (parseInt(hexoVersion) >= 5) {
       currentId = encodeURI(currentId)
     }
 


### PR DESCRIPTION
在 hexo v6 版本中沿用了 hexo v5 生成 toc 的辅助函数，在之前的修复中只兼容了 hexo v5 对该函数的兼容，导致 hexo v6 的目录自动高亮功能失效，现改为 hexo v5 以及其以上版本都使用 encodeURI 来判断目录是否高亮