### PR TITLE
:bug: Fix(style): fix recent post item content overflow

### DIFF
--- a/source/css/_layout/page.styl
+++ b/source/css/_layout/page.styl
@@ -16,6 +16,7 @@ galleryItemStyle(w, h)
 
   .content
     margin-top: 0.5rem
+    word-break: break-word
 
     p
       word-break: break-word


### PR DESCRIPTION
修复文章列表预览内容有长文本时出现溢出的情况。

修复前：
![image](https://user-images.githubusercontent.com/30311024/177950403-bce2123d-6ee7-4ed1-ab43-9428955137b0.png)

修复后：
![image](https://user-images.githubusercontent.com/30311024/177950505-6445a9b7-c24a-47f2-8788-9863afc694cf.png)
